### PR TITLE
build: add latest spdlog

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "protobuf", version = "29.4", repo_name = "com_google_protobuf"
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
+bazel_dep(name = "spdlog", version = "1.15.3")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 
 # Gazebo Dependencies


### PR DESCRIPTION
avoid this build error on macos
```
INFO: Analyzed target //:spawn_model (0 packages loaded, 0 targets configured).
ERROR: /private/var/tmp/_bazel_daisuke/90ed9f3b459e9b39427ee24c0df05baf/external/gz-utils~/log/BUILD.bazel:19:11: Compiling log/src/SplitSink.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target @@gz-utils~//log:SplitSink) external/rules_cc~~cc_configure_extension~local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object ... (remaining 49 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from external/gz-utils~/log/src/SplitSink.cc:20:
In file included from external/gz-utils~/log/include/gz/utils/log/SplitSink.hh:28:
In file included from external/spdlog~/include/spdlog/details/log_msg.h:6:
external/spdlog~/include/spdlog/common.h:373:54: error: no template named 'basic_format_string' in namespace 'fmt'; did you mean 'basic_format_arg'?
  373 | inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt)
      |                                                 ~~~~~^
bazel-out/darwin_arm64-fastbuild/bin/external/fmt~/_virtual_includes/fmt/fmt/base.h:2476:35: note: 'basic_format_arg' declared here
 2476 | template <typename Context> class basic_format_arg {
      |                                   ^
In file included from external/gz-utils~/log/src/SplitSink.cc:20:
In file included from external/gz-utils~/log/include/gz/utils/log/SplitSink.hh:28:
In file included from external/spdlog~/include/spdlog/details/log_msg.h:6:
external/spdlog~/include/spdlog/common.h:373:54: error: too many template arguments for class template 'basic_format_arg'
  373 | inline fmt::basic_string_view<T> to_string_view(fmt::basic_format_string<T, Args...> fmt)
      |                                                      ^                      ~~~~~~~~
bazel-out/darwin_arm64-fastbuild/bin/external/fmt~/_virtual_includes/fmt/fmt/base.h:2476:35: note: template is declared here
 2476 | template <typename Context> class basic_format_arg {
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~       ^
2 errors generated.
Target //:spawn_model failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 10.329s, Critical Path: 9.86s
INFO: 101 processes: 16 internal, 85 darwin-sandbox.
ERROR: Build did NOT complete successfully
ERROR: Build failed. Not running target
```